### PR TITLE
Type fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -172,7 +172,7 @@ declare module 'xorm' {
 		 * if you omit one column in the object, that column won't be touched at all
 		 *  eg. if you don't want updatedAt => `timestamps = {createdAt: 'createdAt'}`
 		 */
-		static timestamps: boolean;
+		static timestamps: boolean | {createdAt?: string, updatedAt?: string};
 		static timestampColumns: string[];
 		static softDelete: boolean;
 		static softDeleteColumn: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ import {
 	QueryBuilderYieldingOneOrNone,
 	snakeCaseMappers as snakeCaseMappersType,
 	knexSnakeCaseMappers as knexSnakeCaseMappersType,
+	Transaction,
 } from 'objection';
 import * as Knex from 'knex';
 import { RedisCache, Cache } from 'sm-utils';
@@ -50,7 +51,7 @@ declare module 'xorm' {
 		loaderCtx(ctx: object|null): void;
 		find(...args: any[]): QueryBuilderYieldingOneOrNone<QM>;
 		save(fields: Partial<QM>): QueryBuilderYieldingCount<QM, RM>;
-		saveAndFetch<QM extends Model>(fields: object): QueryBuilderYieldingOne<QM>;
+		saveAndFetch(fields: Partial<QM>): QueryBuilderYieldingOne<QM>;
 		updateById(id: any, fields: PartialUpdate<QM>): QueryBuilderYieldingCount<QM, RM>;
 		patchById(id: any, fields: PartialUpdate<QM>): QueryBuilderYieldingCount<QM, RM>;
 		whereByOr(obj: Partial<QM>): QueryBuilder<QM, RM, RV>;
@@ -237,6 +238,10 @@ declare module 'xorm' {
 		static find<QM extends Model>(
 			this: Constructor<QM>,
 			...args: any[],
+		): QueryBuilder<QM>;
+		static query<QM extends ObjectionModel>(
+			this: Constructor<QM>,
+			trxOrKnex?: Transaction | Knex,
 		): QueryBuilder<QM>;
 
 		static RelatedQueryBuilder: typeof QueryBuilder;

--- a/index.d.ts
+++ b/index.d.ts
@@ -194,7 +194,7 @@ declare module 'xorm' {
 		 * }
 		 * if this is an object, all items accessed with loadById are cached for ttl duration
 		 */
-		static cacheById: boolean;
+		static cacheById: boolean | {ttl: number | string, columns: string[], excludedColumns: string[], maxLocalItems: number};
 		/**
 		 * @param prefix default value: 'a'
 		 */
@@ -216,10 +216,17 @@ declare module 'xorm' {
 		static getIdLoader(options?: loaderOptions): DataLoader<any, any>;
 		
 		static fromJsonSimple<QM extends Model>(json: object): QM;
-		static loadByColumn<QM extends Model>(columnName: string|string[], columnValue: any, options?: loadByOptions): Promise<QM|null>;
-		static loadByColumn<QM extends Model>(columnName: string|string[], columnValue: any[], options?: loadByOptions): Promise<Array<QM|null>>;
+		static loadByColumn<QM extends Model>(columnName: string, columnValue: any, options?: loadByOptions): Promise<QM|null>;
+		static loadByColumn<QM extends Model>(columnName: string, columnValue: any[], options?: loadByOptions): Promise<(QM|null)[]>;
+		static loadByColumn<QM extends Model>(columnName: string, columnValue: any[], options?: loadByOptions & {nonNull: true}): Promise<QM[]>;
+
+		static loadByColumn<QM extends Model>(columnName: string[], columnValue: any[], options?: loadByOptions): Promise<QM|null>;
+		static loadByColumn<QM extends Model>(columnName: string[], columnValue: any[][], options?: loadByOptions): Promise<(QM|null)[]>;
+		static loadByColumn<QM extends Model>(columnName: string[], columnValue: any[][], options?: loadByOptions & {nonNull: true}): Promise<QM[]>;
+
 		static loadById<QM extends Model>(this: Constructor<QM>, id: any, options?: loadByOptions): Promise<QM|null>;
 		static loadById<QM extends Model>(this: Constructor<QM>, id: any[], options?: loadByOptions): Promise<Array<QM|null>>;
+		static loadById<QM extends Model>(this: Constructor<QM>, id: any[], options?: loadByOptions & {nonNull: true}): Promise<Array<QM>>;
 
 		static loadManyByColumn<QM extends Model>(columnName: string, columnValue: any, options?: loadManyOptions): Promise<QM|null>;
 		static loadManyByColumn<QM extends Model>(columnName: string, columnValue: any[], options?: loadManyOptions): Promise<Array<QM|null>>;


### PR DESCRIPTION
- [x] Fix types of loadBy functions, returning `Model | Model[]` currently
- [x] overload them properly
- [x] `query()` type now changed to return xorm's query builder instead of original objection query builder
- [x] fix type of timstamps