### PR TITLE
Export limit filter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -273,4 +273,11 @@ declare module 'xorm' {
 		$parseJson(json: Pojo, opt?: ModelOptions): Pojo;
 		static getJsonSchema(): JsonSchema;
 	}
+
+	function limitFilter<T, X>(values: T[], options: {limit?: number, offset?: number, nonNull: true, fn: (vals: T[]) => Promise<X[]>}): Promise<X[]>
+	function limitFilter<T, X>(values: T[], options: {limit?: number, offset?: number, nonNull?: boolean, fn: (vals: T[]) => Promise<X[]>}): Promise<(X | null)[]>
+	function limitFilter<T, X = T>(values: T[], options?: {limit?: number, offset?: number, nonNull?: boolean}): Promise<X[]>
+	// Non Promise overloads
+	function limitFilter<T, X>(values: T[], options: {limit?: number, offset?: number, nonNull: true, fn: (vals: T[]) => X[]}): Promise<X[]>
+	function limitFilter<T, X>(values: T[], options: {limit?: number, offset?: number, nonNull?: boolean, fn: (vals: T[]) => X[]}): Promise<(X | null)[]>
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import Model from './model';
+import Model, {limitFilter} from './model';
 import QueryBuilder from './query_builder';
 import UserError from './user_error';
 
@@ -20,4 +20,5 @@ export {
 	Model,
 	QueryBuilder,
 	UserError,
+	limitFilter,
 };

--- a/src/model.js
+++ b/src/model.js
@@ -95,6 +95,14 @@ async function handleResult(obj, options) {
 	return obj;
 }
 
+/**
+ * @template T
+ * @template X
+ * @param {T[]} values
+ * @param {(vals: T[]) => Promise<X[]>} fn
+ * @param {{limit?: number, offset?: number, nonNull?: boolean}} [options]
+ * @returns {Promise<X[]>}
+ */
 async function limitFilter(values, fn, options = {}) {
 	const {limit, offset = 0, nonNull = false} = options;
 	if (limit === 0 || offset >= values.length) return [];
@@ -1157,3 +1165,7 @@ BaseModel.QueryBuilder = BaseQueryBuilder;
 BaseModel.RelatedQueryBuilder = BaseQueryBuilder;
 
 export default BaseModel;
+
+export {
+	limitFilter,
+};


### PR DESCRIPTION
Exporting limit filter so that it can be used in custom implementations of loadById.
Also made `fn` optional (default is v => v) so that an array can directly be filtered